### PR TITLE
fix: fix Test AZD deployment button that was hitting the old endpoint

### DIFF
--- a/packages/app/js/azd-provision.js
+++ b/packages/app/js/azd-provision.js
@@ -271,8 +271,9 @@ function runAzdProvisionTest() {
           }
         };
       }
+      const MAX_POLLING_ATTEMPTS = 60; // ~30 minutes at 30s
       let attempts = 0;
-      const maxAttempts = 60; // ~30 minutes at 30s
+      const maxAttempts = MAX_POLLING_ATTEMPTS;
 
       const pollOnce = async () => {
         attempts++;


### PR DESCRIPTION
closes #62 