### PR TITLE
Fix: Docs config - rename integration function

### DIFF
--- a/packages/app/js/analyzer.js
+++ b/packages/app/js/analyzer.js
@@ -316,7 +316,7 @@ class TemplateAnalyzer {
       // Run repository-level configuration validations early (docs-config rules)
       // Only run docs-specific repo validations when the docs ruleset is selected
       if (ruleSet === 'docs') {
-        TemplateAnalyzerDocs.prototype.validateRepoConfiguration(
+        TemplateAnalyzerDocs.prototype.validateDocConfiguration(
           config,
           repoInfo,
           defaultBranch,

--- a/packages/app/js/ruleset-docs/analyzer.js
+++ b/packages/app/js/ruleset-docs/analyzer.js
@@ -68,7 +68,7 @@ class TemplateAnalyzerDocs {
    * @param {Array} issues
    * @param {Array} compliant
    */
-  validateRepoConfiguration(config, repoInfo, defaultBranch, files, issues, compliant) {
+  validateDocConfiguration(config, repoInfo, defaultBranch, files, issues, compliant) {
     try {
       // Run the existing default branch rule (docs-config defaultBranch.mustBe)
       this.evaluateDefaultBranchRule(config, repoInfo, defaultBranch, issues, compliant);


### PR DESCRIPTION
# Summary
Rename integraion function so all docs config validation can go flow from that one function

Fixes #

# Type
- [ ] feat (feature)
- [ ] dev (tooling/config/docs/build)
- [ ] test (tests only)
- [ ] fx (bug fix)

# Details
- What’s the user impact?
- Any breaking changes?
- Alternatives considered?

# How to Test
Provide clear steps:
1. 
2. 
3. 

# Checklist
- [ ] Includes or updates tests (Playwright E2E where applicable)
- [ ] No native alerts/confirms/prompts introduced (uses notifications)
- [ ] Ran formatting and checks in `src/frontend` (`npm run format`, `npm run format:check`)
- [ ] Updated docs (README/spec/etc.) if behavior/config changed
- [ ] CI is green

# Screenshots/Recordings (optional)
If UI changes, include before/after.
